### PR TITLE
Bugfix/2 sensor ids

### DIFF
--- a/ecobee-poly.py
+++ b/ecobee-poly.py
@@ -230,8 +230,12 @@ class Controller(polyinterface.Controller):
                     if 'remoteSensors' in tstat:
                         for sensor in tstat['remoteSensors']:
                             if 'id' in sensor and 'name' in sensor:
-                                sensorAddress = re.sub('\:', '', sensor['id']).lower()[:12]
-                                # sensorAddress = 's{}'.format(sensor['code'].lower())
+                                if sensor['type'] == 'thermostat':
+                                    sensorAddress = 's{}'.format(thermostatId)
+                                else:
+                                    sensorAddress = re.sub('\:', '', sensor['id']).lower()[:12]
+                                    sensorAddress = '{}_{}'.format(sensorAddress, sensor['code'].lower())
+
                                 if not sensorAddress in self.nodes:
                                     sensorName = '{} Sensor - {}'.format(thermostat['name'], sensor['name'])
                                     self.addNode(Sensor(self, address, sensorAddress, sensorName, useCelsius))

--- a/node_types.py
+++ b/node_types.py
@@ -215,7 +215,12 @@ class Thermostat(polyinterface.Node):
         if node.primary == self.address and node.type == 'sensor':
           for sensor in self.tstat['remoteSensors']:
             if 'id' in sensor:
-              sensorId = re.sub('\:', '', sensor['id']).lower()[:12]
+              if sensor['type'] == 'thermostat':
+                sensorId = 's{}'.format(self.tstat['identifier'])
+              else:
+                sensorId = re.sub('\:', '', sensor['id']).lower()[:12]
+                sensorId = '{}_{}'.format(sensorId, sensor['code'].lower())
+
               if node.address == sensorId:
                 node.update(sensor)
         if node.primary == self.address and (node.type == 'weather' or node.type == 'forecast'):


### PR DESCRIPTION
Proposed fix for #2. Formats the address for normal sensors using {id}_{code} and for the thermostat sensors s{thermostatId} so it's consistent with the Forecast and Weather node addresses.

Note: This will be a breaking change for existing users as all sensor nodes will end up with a new address. I didn't see any way to do a migration of the existing nodes but if there is let me know.